### PR TITLE
Clean up register_hud_element changes, make sure settings are applied

### DIFF
--- a/scripts/mods/kill_tracker/HudElementKillCount.lua
+++ b/scripts/mods/kill_tracker/HudElementKillCount.lua
@@ -6,11 +6,10 @@ local UIHudSettings = require("scripts/settings/ui/ui_hud_settings")
 local UIWidget = require("scripts/managers/ui/ui_widget")
 local UIFonts = mod:original_require("scripts/managers/ui/ui_fonts")
 
-local font_size = mod.label_size
-local font_offset = mod.label_y_offset
 local font_size_anim = 140
-local size = { 60, font_size }
+local size = { 60, 0 }
 local sizeAnim = { 1000, font_size_anim }
+local font_offset = { 0, 0, 0 }
 local scenegraph_definition = {
 	screen = UIWorkspaceSettings.screen,
 	counterContainer = {
@@ -19,7 +18,7 @@ local scenegraph_definition = {
 		vertical_alignment = "bottom",
 		horizontal_alignment = "center",
 		size = size,
-		position = { -125, font_offset, 10 },
+		position = { -125, 0, 10 },
 	},
 	counterLabelContainer = {
 		parent = "screen",
@@ -27,14 +26,14 @@ local scenegraph_definition = {
 		vertical_alignment = "bottom",
 		horizontal_alignment = "center",
 		size = size,
-		position = { -75, font_offset, 10 },
+		position = { -75, 0, 10 },
 	},
 	animContainer = {
 		parent = "screen",
 		vertical_alignment = "center",
 		horizontal_alignment = "center",
 		size = sizeAnim,
-		position = { mod.anim_x_offset , mod.anim_y_offset, 10 },
+		position = mod.anim_offset,
 	},
 	comboContainer = {
 		parent = "screen",
@@ -42,7 +41,7 @@ local scenegraph_definition = {
 		vertical_alignment = "bottom",
 		horizontal_alignment = "center",
 		size = size,
-		position = { 75, font_offset, 10 },
+		position = { 75, 0, 10 },
 	},
 	newComboContainer = {
 		parent = "screen",
@@ -50,7 +49,7 @@ local scenegraph_definition = {
 		vertical_alignment = "bottom",
 		horizontal_alignment = "center",
 		size = size,
-		position = { 67, font_offset, 10 },
+		position = { 67, 0, 10 },
 	},
 	comboLabelContainer = {
 		parent = "screen",
@@ -58,7 +57,7 @@ local scenegraph_definition = {
 		vertical_alignment = "bottom",
 		horizontal_alignment = "center",
 		size = size,
-		position = { 135, font_offset, 10 },
+		position = { 135, 0, 10 },
 	},
 	testContainer = {
 		parent = "screen",
@@ -72,63 +71,72 @@ local scenegraph_definition = {
 
 local styleCounter = {
 	line_spacing = 1.2,
-	font_size = font_size,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.default_color,
 	size = size,
 	text_horizontal_alignment = "center",
 	text_vertical_alignment = "center",
+	offset = font_offset,
 }
 
 local styleCounterLabel = {
 	line_spacing = 1.2,
-	font_size = font_size/2,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.default_color,
 	size = size,
 	text_horizontal_alignment = "center",
 	text_vertical_alignment = "center",
+	offset = font_offset,
 }
 
 local styleAnimated = {
 	line_spacing = 1.2,
-	font_size = font_size,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.anim_color,
 	size = sizeAnim,
 	text_horizontal_alignment = "center",
 	text_vertical_alignment = "bottom",
-	offset = { 0, 10, 10 },
+	offset = { 0, 0, 0 },
 }
 
 local styleComboCounter = {
 	line_spacing = 1.2,
-	font_size = font_size,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.default_color,
 	size = size,
 	text_horizontal_alignment = "center",
 	text_vertical_alignment = "center",
+	offset = font_offset,
 }
 
 local styleNewComboCounter = {
 	line_spacing = 1.2,
-	font_size = font_size,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.new_combo_color,
 	size = size,
 	text_horizontal_alignment = "center",
 	text_vertical_alignment = "center",
+	offset = { 0, 0, 0 },
 }
 
 local styleComboCounterLabel = {
 	line_spacing = 1.2,
-	font_size = font_size/2,
+	drop_shadow = true,
+	font_type = "machine_medium",
+	text_color = mod.default_color,
+	size = size,
+	text_horizontal_alignment = "center",
+	text_vertical_alignment = "center",
+	offset = font_offset,
+}
+
+local styleTest = {
+	line_spacing = 1.2,
 	drop_shadow = true,
 	font_type = "machine_medium",
 	text_color = mod.default_color,
@@ -137,16 +145,21 @@ local styleComboCounterLabel = {
 	text_vertical_alignment = "center",
 }
 
-local styleTest = {
-	line_spacing = 1.2,
-	font_size = font_size,
-	drop_shadow = true,
-	font_type = "machine_medium",
-	text_color = mod.default_color,
-	size = size,
-	text_horizontal_alignment = "center",
-	text_vertical_alignment = "center",
-}
+mod.apply_widget_settings = function()
+	local font_size = mod.label_size
+
+	size[2] = font_size
+	styleCounter.font_size = font_size
+	styleCounterLabel.font_size = font_size/2
+	styleAnimated.font_size = font_size
+	styleComboCounter.font_size = font_size
+	styleNewComboCounter.font_size = font_size
+	styleComboCounterLabel.font_size = font_size/2
+	styleTest.font_size = font_size
+
+	font_offset[2] = mod.label_y_offset
+end
+mod.apply_widget_settings()
 
 local widget_definitions = {
 	killCounter = UIWidget.create_definition(
@@ -261,7 +274,6 @@ HudElementKillCount.init = function(self, parent, draw_layer, start_scale)
 		scenegraph_definition = scenegraph_definition,
 		widget_definitions = widget_definitions,
 	})
-	self.is_in_hub = mod._is_in_hub()
 	self.combo_timer = 0
 	self.timer_running = false
 	self.combo_timer_percentage = 0
@@ -334,18 +346,6 @@ end
 
 HudElementKillCount.update = function(self, dt, t, ui_renderer, render_settings, input_service)
 	HudElementKillCount.super.update(self, dt, t, ui_renderer, render_settings, input_service)	
-
-	if self.is_in_hub then		
-		self._widgets_by_name.killCounter.content.text = tostring("")
-		self._widgets_by_name.killCounterLabel.content.text = tostring("")
-		self._widgets_by_name.killCombo.content.text = tostring("")
-		self._widgets_by_name.killComboLabel.content.text = tostring("")
-		self._widgets_by_name.animatedCounter.content.text = tostring("")
-		self._widgets_by_name.newKillCombo.content.text = tostring("")
-
-		self._widgets_by_name.testWidget.content.text = tostring("")
-		return
-	end
 	-- self:_test_dt(self._widgets_by_name.testWidget)
 
 	if self.timer_running then
@@ -365,7 +365,7 @@ HudElementKillCount.update = function(self, dt, t, ui_renderer, render_settings,
 		if mod.show_cringe then
 			font_scale = _scale_by_cringe_factor(math.max(anim_font_scale, self.anim_kill_combo))
 		end
-		self._widgets_by_name.animatedCounter.style.text.font_size = (font_size * anim_font_scale) + math.ceil(font_scale - 0.5)
+		self._widgets_by_name.animatedCounter.style.text.font_size = (mod.label_size * anim_font_scale) + math.ceil(font_scale - 0.5)
 
 		self._widgets_by_name.animatedCounter.alpha_multiplier = alpha
 		self._widgets_by_name.animatedCounter.style.text.offset[2] = -anim_pos_y_offset
@@ -406,14 +406,14 @@ HudElementKillCount.update = function(self, dt, t, ui_renderer, render_settings,
 		self._widgets_by_name.killCombo.content.text = tostring("")
 		self._widgets_by_name.killComboLabel.content.text = tostring("")
 	end
-	if self.new_highest_kill_combo and mod.show_kill_combos and (self._widgets_by_name.newKillCombo.style.text.offset[2] > -80) then
-		local comboAlpha = (self._widgets_by_name.newKillCombo.style.text.offset[2] * -1) / 80
+	if self.new_highest_kill_combo and mod.show_kill_combos and (self._widgets_by_name.newKillCombo.style.text.offset[2] > mod.label_y_offset - 80) then
+		local comboAlpha = (mod.label_y_offset - self._widgets_by_name.newKillCombo.style.text.offset[2]) / 80
 		self._widgets_by_name.newKillCombo.alpha_multiplier = 1 - comboAlpha
 		self._widgets_by_name.newKillCombo.style.text.offset[2] = self._widgets_by_name.newKillCombo.style.text.offset[2] - comboAlpha * 2 - 0.2
 		self._widgets_by_name.newKillCombo.content.text = tostring("+" .. tostring(mod.highest_kill_combo))
 	else
 		self.new_highest_kill_combo = false
-		self._widgets_by_name.newKillCombo.style.text.offset[2] = 0
+		self._widgets_by_name.newKillCombo.style.text.offset[2] = mod.label_y_offset
 		self._widgets_by_name.newKillCombo.content.text = tostring("")
 	end
 end

--- a/scripts/mods/kill_tracker/kill_tracker.lua
+++ b/scripts/mods/kill_tracker/kill_tracker.lua
@@ -79,10 +79,6 @@ mod.on_setting_changed = function()
 	apply_settings(false)
 end
 
-mod.add_to_killcounter = function()
-	mod:notify("wtf how did u get here")
-end
-
 function mod.on_game_state_changed(status, state_name)
 	-- Clear row values on game state enter
 	if state_name == 'GameplayStateRun' or state_name == "StateGameplay" and status == "enter" then
@@ -105,7 +101,7 @@ function(self, damage_profile, attacked_unit, attacking_unit, attack_direction, 
 	local unit_data_extension = ScriptUnit.has_extension(attacked_unit, "unit_data_system")
 	local breed_or_nil = unit_data_extension and unit_data_extension:breed()
 	local target_is_minion = breed_or_nil and Breed.is_minion(breed_or_nil)		
-	if target_is_minion then
+	if target_is_minion and mod.add_to_killcounter then
 		mod.add_to_killcounter()
 	end	
 end)

--- a/scripts/mods/kill_tracker/kill_tracker.lua
+++ b/scripts/mods/kill_tracker/kill_tracker.lua
@@ -4,28 +4,12 @@
 
 local mod = get_mod("kill_tracker")
 
-mod:io_dofile("kill_tracker/scripts/mods/kill_tracker/utils")
-
 local Breed = mod:original_require("scripts/utilities/breed")
 
 mod.kill_counter = 0
 mod.highest_kill_combo = 0
 mod.kill_counter_label = mod:localize("kill_count_hud")
 mod.kill_combo_label = mod:localize("kill_combo_hud")
-
-mod:register_hud_element({
-	filename = "kill_tracker/scripts/mods/kill_tracker/HudElementKillCount",
-	class_name = "HudElementKillCount",
-	visibility_groups = {
-		"tactical_overlay",
-		"alive",
-		"communication_wheel",
-	},
-	use_hud_scale = true,
-	validation_function = function(params)
-		return Managers.state.game_mode:game_mode_name() ~= "hub"
-	end
-})
 
 local function apply_settings(reset_stats)
 	if reset_stats then
@@ -36,8 +20,17 @@ local function apply_settings(reset_stats)
 	mod.min_kill_combo = mod:get("min_kill_combo")
 	mod.show_cringe = mod:get("show_cringe")
 	mod.cringe_factor = mod:get("cringe_factor")
-	mod.anim_x_offset = mod:get("anim_container_x_offset")
-	mod.anim_y_offset = mod:get("anim_container_y_offset")
+
+	if mod.anim_offset then
+		mod.anim_offset[1] = mod:get("anim_container_x_offset")
+		mod.anim_offset[2] = mod:get("anim_container_y_offset")
+	else
+		mod.anim_offset = {
+			mod:get("anim_container_x_offset"),
+			mod:get("anim_container_y_offset"),
+			10
+		}
+	end
 
 	--From 'color_definitions' (Darktide Source Code)
 	local color_code = mod:get("anim_color")
@@ -61,15 +54,26 @@ local function apply_settings(reset_stats)
 	mod.anim_color = Color[color_code](transparency,true)
 	mod.fade_color = Color[color_code](transparency,true)
 	mod.new_combo_color = Color.dark_turquoise(255, true)
+
+	if mod.apply_widget_settings then
+		mod.apply_widget_settings()
+	end
 end
 
-mod.reload_mods = function()
-	apply_settings(true)
-end
-
-mod.on_all_mods_loaded = function()
-	apply_settings(true)
-end
+apply_settings(true)
+mod:register_hud_element({
+	filename = "kill_tracker/scripts/mods/kill_tracker/HudElementKillCount",
+	class_name = "HudElementKillCount",
+	visibility_groups = {
+		"tactical_overlay",
+		"alive",
+		"communication_wheel",
+	},
+	use_hud_scale = true,
+	validation_function = function(params)
+		return Managers.state.game_mode:game_mode_name() ~= "hub"
+	end
+})
 
 mod.on_setting_changed = function()
 	apply_settings(false)


### PR DESCRIPTION
This is kind of a messy PR cuz I got a bit carried away....... so it's really a 2-in-1.

1. Clean up register_hud_element

Because the validation function in `register_hud_element` prevents the element from being drawn in the hub anyway, the additional checks to prevent drawing in the hub are no longer necessary, so they were removed.

There was an issue that would break the element when reloading mods (though before using `register_hud_element`, reloading mods would crash the game). To fix this, `apply_settings` is run when loading the mod, rather than on mod reload or all mods loaded. It also does so before registering the element.

2. Settings are applied in the widget

When settings are applied, the widget now also updates itself accordingly.